### PR TITLE
lualine integration

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,10 +1,10 @@
 local keymap = vim.api.nvim_set_keymap
 
-vim.cmd("set number")            -- show numbered lines
-vim.cmd("set expandtab")         -- convert tabs to spaces
-vim.cmd("set shiftwidth=2")      -- the number of spaces inserted for each indentation
-vim.cmd("set tabstop=2")         -- insert 2 spaces for a tab
-vim.cmd("set termguicolors")     -- enable 24-bit RGB color in the terminal
+vim.cmd("set number")        -- show numbered lines
+vim.cmd("set expandtab")     -- convert tabs to spaces
+vim.cmd("set shiftwidth=2")  -- the number of spaces inserted for each indentation
+vim.cmd("set tabstop=2")     -- insert 2 spaces for a tab
+vim.cmd("set termguicolors") -- enable 24-bit RGB color in the terminal
 
 -- leader key is <space>
 vim.g.mapleader = " "
@@ -21,6 +21,7 @@ if not (vim.uv or vim.loop).fs_stat(lazypath) then
   })
 end
 vim.opt.rtp:prepend(lazypath)
+vim.opt.showmode = false -- we don't need to show mode information like "INSERT", "VISUAL" in default status line as it will be shown in lualine
 
 require("lazy").setup("plugins")
 

--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -8,6 +8,7 @@
   "gruvbox": { "branch": "master", "commit": "f1ecde848f0cdba877acb0c740320568252cc482" },
   "lazy.nvim": { "branch": "main", "commit": "eb4957442e3182f051b0ae11da32e06d22c190e3" },
   "lazygit.nvim": { "branch": "main", "commit": "ad3e1ea592f9d13e86e0d4e850224d9d78069508" },
+  "lualine.nvim": { "branch": "master", "commit": "6a40b530539d2209f7dc0492f3681c8c126647ad" },
   "mason-lspconfig.nvim": { "branch": "main", "commit": "8db12610bcb7ce67013cfdfaba4dd47a23c6e851" },
   "mason.nvim": { "branch": "main", "commit": "0950b15060067f752fde13a779a994f59516ce3d" },
   "neo-tree.nvim": { "branch": "v3.x", "commit": "29f7c215332ba95e470811c380ddbce2cebe2af4" },

--- a/lua/plugins/lualine.lua
+++ b/lua/plugins/lualine.lua
@@ -1,0 +1,7 @@
+return {
+  'nvim-lualine/lualine.nvim',
+  dependencies = { 'nvim-tree/nvim-web-devicons' },
+  config = function()
+    require("lualine").setup {}
+  end
+}


### PR DESCRIPTION
Add lualine.nvim and configures the default neovim statusline to not show mode information.